### PR TITLE
updated the configuration method with environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Revel Redis
 A simple Redis module for the [Revel Framework](http://revel.github.io/). Adds a shared [gosexy/redis](https://github.com/gosexy/redis) client to any controller, with a shared connection across all requests.
 
@@ -22,6 +21,8 @@ redis.password =
 ##############################################
 ```
 
+If you want to use an environment variable instead of a hardcoded conf value, see https://revel.github.io/manual/appconf.html#environment-variables
+
 Now in any controller you want some Redis action, import the library, and add the `RedisController` to your controller struct.
 
 ```go
@@ -42,9 +43,6 @@ func (c *MyController) DoStuff() revel.Result{
 }
 ```
 
-### ENV
-If you want to use an environment variable instead of a hardcoded conf value, Revel Redis will prioritise `REDIS_URL` in the format `redis://hostname:port`, over the conf values.
-
 ## Who
 
 Created with love by [Mal Curtis](http://github.com/snikch)
@@ -58,7 +56,6 @@ MIT. See license file.
 ## Todo
 
 *  Handle global processes when starting another instance of hack
-
 
 ## Contributing
 

--- a/revel-redis.go
+++ b/revel-redis.go
@@ -4,11 +4,6 @@ package revelRedis
 import (
 	"github.com/gosexy/redis"
 	"github.com/revel/revel"
-	"os"
-	"regexp"
-	"strings"
-	"strconv"
-	"fmt"
 )
 
 var (
@@ -16,57 +11,15 @@ var (
 )
 
 func Init() {
-	// Read configuration.
-	var found bool
-	var host string
-	var password string
-	var port int
-
-	// First look in the environment for REDIS_URL
-	url := os.Getenv("REDIS_URL")
-
-	// Check it matches a redis url format
-	if match, _ := regexp.MatchString("^redis://(.*:.*@)?[^@]*:[0-9]+$", url); match {
-
-		// Remove the scheme
-		url = strings.Replace(url, "redis://", "", 1)
-		parts := strings.Split(url, "@")
-
-		// Smash off the credentials
-		if len(parts) > 1 {
-			url = parts[1]
-			password = strings.Split(parts[0], ":")[1]
-		}
-
-		// Split to get the port off the end
-		parts = strings.Split(url, ":")
-		if len(parts) != 2 {
-			revel.ERROR.Fatal(fmt.Sprintf("REDIS_URL format was incorrect (%s)", url))
-		}
-
-		// Get the host and possible password
-		var port64 int64
-		host = parts[0]
-		port64, _ = strconv.ParseInt(parts[1], 0, 0)
-		if port64 > 0{
-			port = int(port64)
-		}
-	}
-
 	// Then look into the configuration for redis.host and redis.port
-	if len(host) == 0 {
-		if host, found = revel.Config.String("redis.host"); !found {
-			revel.ERROR.Fatal("No redis.host found.")
-		}
+	host, found := revel.Config.String("redis.host")
+	if !found {
+		revel.ERROR.Fatal("No redis.host found.")
 	}
-	if len(password) == 0 {
-		password, _ = revel.Config.String("redis.password")
-	}
-	if port == 0 {
-		if port, found = revel.Config.Int("redis.port"); !found {
-			port = 6379
-		}
-	}
+
+	port := revel.Config.IntDefault("redis.port", 6379)
+
+	password, _ := revel.Config.String("redis.password")
 
 	Redis = redis.New()
 


### PR DESCRIPTION
Hi, again.

Current revel support to use environment variables in `conf/app.conf`, so we can use any environment variables in `conf/app.conf`. I suppose `REDIS_URL` is now not necessary.

Please consider taking this PR in.

Cheers.